### PR TITLE
refactor: update MCP server configuration and entry points

### DIFF
--- a/.cursor/mcp-sample.json
+++ b/.cursor/mcp-sample.json
@@ -41,24 +41,47 @@
         "localhost"
       ]
     },
-    "dpytest-vectorstore-mcp": {
+    "discord-avectorstore-mcp": {
       "command": "uv",
       "args": [
         "run",
-        "./scripts/vectorstore_mcp.py",
+        "--directory",
+        "/Users/malcolm/dev/bossjones/oh-my-ai-docs/src/oh_my_ai_docs",
+        "--env-file",
+        "/Users/malcolm/dev/bossjones/oh-my-ai-docs/.envrc",
+        "avectorstore_mcp",
+        "--module",
+        "discord",
+        "--stdio",
+        "--debug"
+      ]
+    },
+    "dpytest-avectorstore-mcp": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/Users/malcolm/dev/bossjones/oh-my-ai-docs/src/oh_my_ai_docs",
+        "--env-file",
+        "/Users/malcolm/dev/bossjones/oh-my-ai-docs/.envrc",
+        "avectorstore_mcp",
         "--module",
         "dpytest",
         "--stdio",
         "--debug"
       ]
     },
-    "discord-avectorstore-mcp": {
+    "langgraph-avectorstore-mcp": {
       "command": "uv",
       "args": [
         "run",
-        "./src/oh_my_ai_docs/avectorstore_mcp.py",
+        "--directory",
+        "/Users/malcolm/dev/bossjones/oh-my-ai-docs/src/oh_my_ai_docs",
+        "--env-file",
+        "/Users/malcolm/dev/bossjones/oh-my-ai-docs/.envrc",
+        "avectorstore_mcp",
         "--module",
-        "discord",
+        "langgraph",
         "--stdio",
         "--debug"
       ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,8 @@
     version = "0.2.0"
 
     [project.scripts]
-        goobctl = 'oh_my_ai_docs.cli:entry'
+        avectorstore_mcp = 'oh_my_ai_docs.avectorstore_mcp:main'
+        goobctl          = 'oh_my_ai_docs.cli:entry'
 
     [project.urls]
         "Bug Tracker"   = "https://github.com/bossjones/oh-my-ai-docs/issues"

--- a/scripts/vectorstore_mcp.py
+++ b/scripts/vectorstore_mcp.py
@@ -64,7 +64,7 @@ def get_config_info():
     """Get configuration information for display"""
     module_path = DOCS_PATH / args.module
     config = {
-        "server_name": f"{args.module}-docs-mcp-server".lower(),
+        "server_name": f"{args.module}-avectorstore-mcp".lower(),
         "module": args.module,
         "paths": {
             "base_path": str(BASE_PATH),
@@ -121,7 +121,7 @@ def generate_mcp_config() -> dict[str, dict[str, Any]]:
     }
 
     for module in modules:
-        server_name = f"{module}-docs-mcp-server".lower()
+        server_name = f"{module}-avectorstore-mcp".lower()
         server_args = [
             "run",
             "--directory", str(BASE_PATH),
@@ -172,7 +172,7 @@ def vectorstore_session(vectorstore_path: str) -> Generator[dict[str, SKLearnVec
 
 # Create an MCP server with module name
 mcp: FastMCP = FastMCP(
-    f"{args.module}-docs-mcp-server".lower(),
+    f"{args.module}-avectorstore-mcp".lower(),
     debug=args.debug,
     log_level="DEBUG" if args.debug else "INFO",
     transport='stdio',  # Set transport at initialization,

--- a/src/oh_my_ai_docs/avectorstore_mcp.py
+++ b/src/oh_my_ai_docs/avectorstore_mcp.py
@@ -1,4 +1,16 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "langchain-community",
+#     "langchain-core",
+#     "langchain-openai",
+#     "mcp[cli]",
+#     "aiofiles",
+#     "pydantic",
+# ]
+# ///
+
 # async version, will come back to this
 # pyright: reportUnknownArgumentType=false
 # pyright: reportMissingImports=false
@@ -64,6 +76,8 @@ from mcp.types import (
     Tool,
 )
 from pydantic import BaseModel, Field, field_validator
+
+logger = get_logger(__name__)
 
 # Add this after the BASE_PATH and DOCS_PATH declarations
 # Global embeddings configuration
@@ -164,7 +178,7 @@ async def get_config_info():
     """Get configuration information for display"""
     module_path = DOCS_PATH / args.module
     config = {
-        "server_name": f"{args.module}-docs-mcp-server".lower(),
+        "server_name": f"{args.module}-avectorstore-mcp".lower(),
         "module": args.module,
         "paths": {
             "base_path": str(BASE_PATH),
@@ -219,7 +233,7 @@ async def generate_mcp_config() -> dict[str, dict[str, Any]]:
     mcp_config: dict[str, dict[str, Any]] = {"mcpServers": {}}
 
     for module in modules:
-        server_name = f"{module}-docs-mcp-server".lower()
+        server_name = f"{module}-avectorstore-mcp".lower()
         mcp_config["mcpServers"][server_name] = {
             "command": "uv",
             "args": ["run", "--directory", str(BASE_PATH), f"./{relative_script_path}", "--module", module],
@@ -312,7 +326,7 @@ async def vectorstore_session(server: FastMCP) -> AsyncIterator[AppContext]:
 
 
 # Create an MCP server with module name
-mcp_server = FastMCP(f"{args.module}-docs-mcp-server".lower(), lifespan=vectorstore_session)
+mcp_server = FastMCP(f"{args.module}-avectorstore-mcp".lower(), lifespan=vectorstore_session)
 
 
 # Add a tool to query the documentation
@@ -424,9 +438,8 @@ async def get_all_docs(module: str) -> str:
         raise ValueError(f"Error reading documentation file: {e}")
 
 
-if __name__ == "__main__":
-    import asyncio
-
+def main() -> None:
+    """Entry point for the avectorstore MCP server."""
     try:
         if args.list_vectorstores:
             pass
@@ -435,4 +448,9 @@ if __name__ == "__main__":
             mcp_server.run(transport="stdio")
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
+        logger.error(f"Error: {e!s}")
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_avectorstore/test_aserver.py
+++ b/tests/test_avectorstore/test_aserver.py
@@ -72,7 +72,7 @@ class TestAVectorStoreMCPServer:
     @pytest.mark.langchain_tool_integration
     async def test_server_initialization(self, mcp_server_instance: FastMCP):
         """Verify the server name is correctly set based on args."""
-        assert mcp_server_instance.name == f"{TEST_MODULE}-docs-mcp-server"
+        assert mcp_server_instance.name == f"{TEST_MODULE}-avectorstore-mcp"
 
     @pytest.mark.anyio
     @pytest.mark.fastmcp_tools


### PR DESCRIPTION
Revised the project configuration in `pyproject.toml` to include a new script entry for `avectorstore_mcp`. Updated the MCP server initialization in `vectorstore_mcp.py` and `avectorstore_mcp.py` to reflect the new naming convention, changing server names from `docs-mcp-server` to `avectorstore-mcp`. Adjusted the test assertions in `test_aserver.py` to ensure they align with the updated server name. Enhanced the `avectorstore_mcp.py` file with additional comments and a main entry point for better clarity and usability.