### PR TITLE
feat: add GitHub label creation for official releases in release preparation script

### DIFF
--- a/scripts/ci/cz-prepare-release.sh
+++ b/scripts/ci/cz-prepare-release.sh
@@ -166,6 +166,11 @@ if command -v gh >/dev/null; then
         exit 1
     fi
 
+    echo "-- Creating label release --"
+    echo "[running] gh label create release --description \"Label for marking official releases\" --color 28a745 || true"
+    gh label create release --description "Label for marking official releases" --color 28a745 || true
+
+
     echo "-- Creating pull request --"
     PR_TITLE="Prepare for release of ${CURRENT_VERSION} to ${VERSION}"
     PR_BODY="Release preparation triggered by @$(git config user.name).\n\nOnce merged, create a GitHub release for \`${VERSION}\` to publish."


### PR DESCRIPTION
Enhanced the `cz-prepare-release.sh` script to include a command for creating a GitHub label named 'release' with a description and color code. This addition aims to streamline the release process by marking official releases clearly.